### PR TITLE
fix: Ajout d'une contrainte pour contrôler le format d'email

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -44,6 +44,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?int $id = null;
 
     #[Groups(['user:read', 'user:create', 'user:update'])]
+    #[Assert\Email(
+        message: 'The email {{ value }} is not a valid email.',
+    )]
     #[ORM\Column(length: 180, unique: true)]
     private ?string $email = null;
 


### PR DESCRIPTION
Lors d'une inscription ou d'une modification d'email, une contrainte est ajouté pour s'assurer que ce soit bien une adresse mail d'enregistrer, sinon une erreur 400 est envoyé